### PR TITLE
style: replace `deno fmt` with `prettier`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+.env
+.vscode

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,14 @@
+{
+  "arrowParens": "always",
+  "bracketSameLine": false,
+  "bracketSpacing": true,
+  "jsxSingleQuote": false,
+  "printWidth": 80,
+  "proseWrap": "always",
+  "quoteProps": "as-needed",
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "useTabs": false
+}

--- a/README.md
+++ b/README.md
@@ -84,6 +84,18 @@ Using `SESSION` environment variable.
 deno run --allow-env --allow-net=adventofcode.com,deno.land --allow-read ./src/scripts/private.ts --leaderboard 123456 --day 1 --part 2
 ```
 
+### Formatting
+
+For consistency with my other projects, use [Prettier](https://prettier.io/)
+instead of [`deno fmt`](https://deno.land/manual@v1.28.3/tools/formatter) when
+formatting code.
+
+```bash
+npx prettier --write .
+
+pnpm dlx prettier --write .
+```
+
 ## Authors
 
 - Mateusz Aliyev ([@mateuszaliyev](https://github.com/mateuszaliyev))

--- a/src/2022/1/2.ts
+++ b/src/2022/1/2.ts
@@ -2,6 +2,10 @@ import { sum } from "@/utilities/array.ts";
 
 import { getSums } from "./common.ts";
 
-const result = sum(getSums().sort((a, z) => z - a).slice(0, 3));
+const result = sum(
+  getSums()
+    .sort((a, z) => z - a)
+    .slice(0, 3)
+);
 
 console.log(result);

--- a/src/2022/1/common.ts
+++ b/src/2022/1/common.ts
@@ -4,6 +4,8 @@ import { getInput } from "@/utilities/get-input.ts";
 const input = await getInput(import.meta.url);
 
 export const getSums = () =>
-  input.split(`${EOL}${EOL}`).map((block) =>
-    block.split(EOL).reduce((sum, value) => sum + Number(value), 0)
-  );
+  input
+    .split(`${EOL}${EOL}`)
+    .map((block) =>
+      block.split(EOL).reduce((sum, value) => sum + Number(value), 0)
+    );

--- a/src/2022/2/1.ts
+++ b/src/2022/2/1.ts
@@ -3,17 +3,20 @@ import { sum } from "@/utilities/array.ts";
 import { getRounds } from "./common.ts";
 
 const result = sum(
-  getRounds().map((round) => ({
-    "A X": 1 + 3,
-    "A Y": 2 + 6,
-    "A Z": 3 + 0,
-    "B X": 1 + 0,
-    "B Y": 2 + 3,
-    "B Z": 3 + 6,
-    "C X": 1 + 6,
-    "C Y": 2 + 0,
-    "C Z": 3 + 3,
-  }[round]!)),
+  getRounds().map(
+    (round) =>
+      ({
+        "A X": 1 + 3,
+        "A Y": 2 + 6,
+        "A Z": 3 + 0,
+        "B X": 1 + 0,
+        "B Y": 2 + 3,
+        "B Z": 3 + 6,
+        "C X": 1 + 6,
+        "C Y": 2 + 0,
+        "C Z": 3 + 3,
+      }[round]!)
+  )
 );
 
 console.log(result);

--- a/src/2022/2/2.ts
+++ b/src/2022/2/2.ts
@@ -3,17 +3,20 @@ import { sum } from "@/utilities/array.ts";
 import { getRounds } from "./common.ts";
 
 const result = sum(
-  getRounds().map((round) => ({
-    "A X": 3 + 0,
-    "A Y": 1 + 3,
-    "A Z": 2 + 6,
-    "B X": 1 + 0,
-    "B Y": 2 + 3,
-    "B Z": 3 + 6,
-    "C X": 2 + 0,
-    "C Y": 3 + 3,
-    "C Z": 1 + 6,
-  }[round]!)),
+  getRounds().map(
+    (round) =>
+      ({
+        "A X": 3 + 0,
+        "A Y": 1 + 3,
+        "A Z": 2 + 6,
+        "B X": 1 + 0,
+        "B Y": 2 + 3,
+        "B Z": 3 + 6,
+        "C X": 2 + 0,
+        "C Y": 3 + 3,
+        "C Z": 1 + 6,
+      }[round]!)
+  )
 );
 
 console.log(result);

--- a/src/2022/3/2.ts
+++ b/src/2022/3/2.ts
@@ -5,11 +5,11 @@ import { getPriority, getRucksacks } from "./common.ts";
 const result = sum(
   chunk(getRucksacks(), 3).map((rucksacks) =>
     getPriority(
-      rucksacks[0].split("").find((item) =>
-        rucksacks.every((rucksack) => rucksack.includes(item))
-      )!,
+      rucksacks[0]
+        .split("")
+        .find((item) => rucksacks.every((rucksack) => rucksack.includes(item)))!
     )
-  ),
+  )
 );
 
 console.log(result);

--- a/src/2022/3/common.ts
+++ b/src/2022/3/common.ts
@@ -2,7 +2,7 @@ import { EOL } from "@/utilities/eol.ts";
 import { getInput } from "@/utilities/get-input.ts";
 
 const priorities = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".split(
-  "",
+  ""
 );
 
 export const getPriority = (item: string) =>

--- a/src/2022/4/1.ts
+++ b/src/2022/4/1.ts
@@ -1,10 +1,9 @@
 import { getAssignmentPairs } from "./common.ts";
 
-const result = getAssignmentPairs().filter((
-  pair,
-) =>
-  pair[0].every((value) => pair[1].includes(value)) ||
-  pair[1].every((value) => pair[0].includes(value))
+const result = getAssignmentPairs().filter(
+  (pair) =>
+    pair[0].every((value) => pair[1].includes(value)) ||
+    pair[1].every((value) => pair[0].includes(value))
 ).length;
 
 console.log(result);

--- a/src/2022/4/2.ts
+++ b/src/2022/4/2.ts
@@ -1,10 +1,9 @@
 import { getAssignmentPairs } from "./common.ts";
 
-const result = getAssignmentPairs().filter((
-  pair,
-) =>
-  pair[0].some((value) => pair[1].includes(value)) ||
-  pair[1].some((value) => pair[0].includes(value))
+const result = getAssignmentPairs().filter(
+  (pair) =>
+    pair[0].some((value) => pair[1].includes(value)) ||
+    pair[1].some((value) => pair[0].includes(value))
 ).length;
 
 console.log(result);

--- a/src/2022/4/common.ts
+++ b/src/2022/4/common.ts
@@ -4,21 +4,17 @@ import { getInput } from "@/utilities/get-input.ts";
 const input = await getInput(import.meta.url);
 
 export const getAssignmentPairs = () =>
-  input
-    .split(EOL)
-    .map((pair) =>
-      pair
-        .split(",")
-        .reduce<[number[], number[]]>(
-          (ranges, sections, index) => {
-            const [start, end] = sections.split("-").map(Number);
+  input.split(EOL).map((pair) =>
+    pair.split(",").reduce<[number[], number[]]>(
+      (ranges, sections, index) => {
+        const [start, end] = sections.split("-").map(Number);
 
-            for (let section = start; section <= end; section++) {
-              ranges[index].push(section);
-            }
+        for (let section = start; section <= end; section++) {
+          ranges[index].push(section);
+        }
 
-            return ranges;
-          },
-          [[], []],
-        )
-    );
+        return ranges;
+      },
+      [[], []]
+    )
+  );

--- a/src/utilities/array.ts
+++ b/src/utilities/array.ts
@@ -1,16 +1,16 @@
 export const chunk = <T>(array: T[], size: number): T[][] =>
   size > 0
     ? array.reduce<T[][]>((chunks, value, index) => {
-      const chunkIndex = Math.floor(index / size);
+        const chunkIndex = Math.floor(index / size);
 
-      if (!chunks[chunkIndex]) {
-        chunks.push([]);
-      }
+        if (!chunks[chunkIndex]) {
+          chunks.push([]);
+        }
 
-      chunks[chunkIndex].push(value);
+        chunks[chunkIndex].push(value);
 
-      return chunks;
-    }, [])
+        return chunks;
+      }, [])
     : [array];
 
 export const sum = (array: number[]) =>

--- a/src/utilities/get-input.ts
+++ b/src/utilities/get-input.ts
@@ -7,10 +7,10 @@ export const getInput = (baseUrl: string, file?: InputFile) =>
     new URL(
       `./${
         file ??
-          (INPUT_FILES.includes(Deno.args[0] as InputFile)
-            ? Deno.args[0]
-            : "input")
+        (INPUT_FILES.includes(Deno.args[0] as InputFile)
+          ? Deno.args[0]
+          : "input")
       }.txt`,
-      baseUrl,
-    ),
+      baseUrl
+    )
   );


### PR DESCRIPTION
This pull request replaces [`deno fmt`](https://deno.land/manual@v1.28.3/tools/formatter) with [Prettier](https://prettier.io/) as a formatter for consistency with other projects.