### PR TITLE
refactor: make input's EOL character platform-independent

### DIFF
--- a/src/2022/1/common.ts
+++ b/src/2022/1/common.ts
@@ -1,11 +1,10 @@
-import { EOL } from "@/utilities/eol.ts";
 import { getInput } from "@/utilities/get-input.ts";
 
 const input = await getInput(import.meta.url);
 
 export const getSums = () =>
   input
-    .split(`${EOL}${EOL}`)
+    .split("\n\n")
     .map((block) =>
-      block.split(EOL).reduce((sum, value) => sum + Number(value), 0)
+      block.split("\n").reduce((sum, value) => sum + Number(value), 0)
     );

--- a/src/2022/2/common.ts
+++ b/src/2022/2/common.ts
@@ -1,6 +1,5 @@
-import { EOL } from "@/utilities/eol.ts";
 import { getInput } from "@/utilities/get-input.ts";
 
 const input = await getInput(import.meta.url);
 
-export const getRounds = () => input.split(EOL);
+export const getRounds = () => input.split("\n");

--- a/src/2022/3/common.ts
+++ b/src/2022/3/common.ts
@@ -1,4 +1,3 @@
-import { EOL } from "@/utilities/eol.ts";
 import { getInput } from "@/utilities/get-input.ts";
 
 const priorities = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".split(
@@ -10,4 +9,4 @@ export const getPriority = (item: string) =>
 
 const input = await getInput(import.meta.url);
 
-export const getRucksacks = () => input.split(EOL);
+export const getRucksacks = () => input.split("\n");

--- a/src/2022/4/common.ts
+++ b/src/2022/4/common.ts
@@ -1,10 +1,9 @@
-import { EOL } from "@/utilities/eol.ts";
 import { getInput } from "@/utilities/get-input.ts";
 
 const input = await getInput(import.meta.url);
 
 export const getAssignmentPairs = () =>
-  input.split(EOL).map((pair) =>
+  input.split("\n").map((pair) =>
     pair
       .split(",")
       .map((sections) => sections.split("-").map(Number))

--- a/src/utilities/eol.ts
+++ b/src/utilities/eol.ts
@@ -1,1 +1,0 @@
-export const EOL = Deno.build.os === "windows" ? "\r\n" : "\n";

--- a/src/utilities/get-input.ts
+++ b/src/utilities/get-input.ts
@@ -2,15 +2,17 @@ export type InputFile = typeof INPUT_FILES[number];
 
 export const INPUT_FILES = ["example", "input"] as const;
 
-export const getInput = (baseUrl: string, file?: InputFile) =>
-  Deno.readTextFile(
-    new URL(
-      `./${
-        file ??
-        (INPUT_FILES.includes(Deno.args[0] as InputFile)
-          ? Deno.args[0]
-          : "input")
-      }.txt`,
-      baseUrl
+export const getInput = async (baseUrl: string, file?: InputFile) =>
+  (
+    await Deno.readTextFile(
+      new URL(
+        `./${
+          file ??
+          (INPUT_FILES.includes(Deno.args[0] as InputFile)
+            ? Deno.args[0]
+            : "input")
+        }.txt`,
+        baseUrl
+      )
     )
-  );
+  ).replaceAll("\r\n", "\n");


### PR DESCRIPTION
This pull request makes input's EOL character platform-independent by replacing every `\r\n` occurrence with `\n` character.